### PR TITLE
feat: Integrate form builder with Web Form DocType

### DIFF
--- a/frappe/public/js/form_builder/components/AddFieldButton.vue
+++ b/frappe/public/js/form_builder/components/AddFieldButton.vue
@@ -59,12 +59,45 @@ const selected = computed(() => {
 const show = ref(false);
 const autocomplete_value = ref("");
 const fields = computed(() => {
+	const allowed_web_form_fieldtypes = [
+		"Attach",
+		"Attach Image",
+		"Check",
+		"Currency",
+		"Color",
+		"Data",
+		"Date",
+		"Datetime",
+		"Duration",
+		"Float",
+		"HTML",
+		"Int",
+		"Link",
+		"Password",
+		"Phone",
+		"Rating",
+		"Select",
+		"Signature",
+		"Small Text",
+		"Text",
+		"Text Editor",
+		"Table",
+		"Time",
+		"Section Break",
+		"Column Break",
+		"Page Break"
+	];
+
 	let fields = frappe.model.all_fieldtypes
 		.filter((df) => {
-			if (in_list(frappe.model.layout_fields, df)) {
-				return false;
+			if (store.is_web_form) {
+				return allowed_web_form_fieldtypes.includes(df);
+			} else {
+				if (in_list(frappe.model.layout_fields, df)) {
+					return false;
+				}
+				return true;
 			}
-			return true;
 		})
 		.map((df) => {
 			let out = { label: __(df), value: df };

--- a/frappe/public/js/form_builder/components/AddFieldButton.vue
+++ b/frappe/public/js/form_builder/components/AddFieldButton.vue
@@ -85,7 +85,7 @@ const fields = computed(() => {
 		"Time",
 		"Section Break",
 		"Column Break",
-		"Page Break"
+		"Page Break",
 	];
 
 	let fields = frappe.model.all_fieldtypes

--- a/frappe/public/js/form_builder/components/Sidebar.vue
+++ b/frappe/public/js/form_builder/components/Sidebar.vue
@@ -40,7 +40,10 @@ function resize(e) {
 	<div class="sidebar-container" :style="{ width: `${sidebar_width}px` }">
 		<FieldProperties v-if="store.form.selected_field" />
 		<div class="default-state" v-else>
-			<div class="actions" v-if="store.form.layout.tabs.length == 1 && !store.read_only">
+			<div
+				class="actions"
+				v-if="store.form.layout.tabs.length == 1 && !store.read_only && !store.is_web_form"
+			>
 				<button
 					class="new-tab-btn btn btn-default btn-xs"
 					:title="__('Add new tab')"

--- a/frappe/public/js/form_builder/components/Tabs.vue
+++ b/frappe/public/js/form_builder/components/Tabs.vue
@@ -18,9 +18,13 @@ whenever(Backspace, (value) => {
 });
 
 const dragged = ref(false);
-const selected = computed(() => store.selected(store.current_tab.df.name));
-const has_tabs = computed(() => store.form.layout.tabs.length > 1);
-store.form.active_tab = store.form.layout.tabs[0].df.name;
+const selected = computed(() =>
+	store.current_tab ? store.selected(store.current_tab.df.name) : false
+);
+const has_tabs = computed(() => (store.form.layout.tabs?.length ?? 0) > 1);
+if (store.form.layout.tabs?.length) {
+	store.form.active_tab = store.form.layout.tabs[0].df.name;
+}
 
 function activate_tab(tab) {
 	store.activate_tab(tab);
@@ -108,7 +112,7 @@ function delete_tab(tab, with_children) {
 </script>
 
 <template>
-	<div class="tab-header" v-if="store.form.layout.tabs.length > 1">
+	<div class="tab-header" v-if="store.form.layout.tabs.length > 1 && !store.is_web_form">
 		<draggable
 			v-show="has_tabs"
 			class="tabs"

--- a/frappe/public/js/form_builder/form_builder.bundle.js
+++ b/frappe/public/js/form_builder/form_builder.bundle.js
@@ -5,12 +5,13 @@ import FormBuilderComponent from "./FormBuilder.vue";
 import { registerGlobalComponents } from "./globals.js";
 
 class FormBuilder {
-	constructor({ wrapper, frm, doctype, customize }) {
+	constructor({ wrapper, frm, doctype, customize, webform }) {
 		this.$wrapper = $(wrapper);
 		this.frm = frm;
 		this.page = frm.page;
 		this.doctype = doctype;
 		this.customize = customize;
+		this.webform = webform;
 		this.read_only = false;
 
 		this.init();
@@ -67,6 +68,7 @@ class FormBuilder {
 	update_store() {
 		this.store.doctype = this.doctype;
 		this.store.is_customize_form = this.customize;
+		this.store.is_web_form = this.webform;
 		this.store.page = this.page;
 		this.store.frm = this.frm;
 	}

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -173,7 +173,10 @@ export const useStore = defineStore("form-builder-store", () => {
 				frm.value.page.clear_indicator();
 			}
 			read_only.value =
-				!is_customize_form.value && !is_web_form.value && !frappe.boot.developer_mode && !doc.value.custom;
+				!is_customize_form.value &&
+				!is_web_form.value &&
+				!frappe.boot.developer_mode &&
+				!doc.value.custom;
 			preview.value = false;
 		});
 

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -173,7 +173,7 @@ export const useStore = defineStore("form-builder-store", () => {
 				frm.value.page.clear_indicator();
 			}
 			read_only.value =
-				!is_customize_form.value && !frappe.boot.developer_mode && !doc.value.custom;
+				!is_customize_form.value && !is_web_form.value && !frappe.boot.developer_mode && !doc.value.custom;
 			preview.value = false;
 		});
 

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -233,7 +233,7 @@ export const useStore = defineStore("form-builder-store", () => {
 		fields.forEach((df) => {
 			// check if fieldname already exist
 			let duplicate = fields.filter((f) => f.fieldname == df.fieldname);
-			if (duplicate.length > 1) {
+			if (df.fieldname && duplicate.length > 1) {
 				error_message = __("Fieldname {0} appears multiple times", get_field_data(df));
 			}
 

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -14,6 +14,7 @@ export const useStore = defineStore("form-builder-store", () => {
 	let doc = ref(null);
 	let docfields = ref([]);
 	let custom_docfields = ref([]);
+	let web_form_docfields = ref([]);
 	let form = ref({
 		layout: {},
 		active_tab: null,
@@ -22,6 +23,7 @@ export const useStore = defineStore("form-builder-store", () => {
 	let dirty = ref(false);
 	let read_only = ref(false);
 	let is_customize_form = ref(false);
+	let is_web_form = ref(false);
 	let preview = ref(false);
 	let drag = ref(false);
 	let get_animation = "cubic-bezier(0.34, 1.56, 0.64, 1)";
@@ -29,11 +31,13 @@ export const useStore = defineStore("form-builder-store", () => {
 
 	// Getters
 	let get_docfields = computed(() => {
+		if (is_web_form.value) return web_form_docfields.value;
 		return is_customize_form.value ? custom_docfields.value : docfields.value;
 	});
 
 	let current_tab = computed(() => {
-		return form.value.layout.tabs.find((tab) => tab.df.name == form.value.active_tab);
+		if (!form.value.layout.tabs || !form.value.layout.tabs.length) return null;
+		return form.value.layout.tabs.find((tab) => tab.df.name == form.value.active_tab) || null;
 	});
 
 	const active_element = useActiveElement();
@@ -51,13 +55,18 @@ export const useStore = defineStore("form-builder-store", () => {
 	}
 
 	function get_df(fieldtype, fieldname = "", label = "") {
-		let docfield = is_customize_form.value ? "Customize Form Field" : "DocField";
+		let docfield = is_web_form.value
+			? "Web Form Field"
+			: is_customize_form.value
+			? "Customize Form Field"
+			: "DocField";
 		let df = frappe.model.get_new_doc(docfield);
 		df.name = frappe.utils.get_random(8);
 		df.fieldtype = fieldtype;
 		df.fieldname = fieldname;
 		df.label = label;
 		is_customize_form.value && (df.is_custom_field = 1);
+		is_web_form.value && (df.parent = frm.value.doc.name);
 		return df;
 	}
 
@@ -95,16 +104,29 @@ export const useStore = defineStore("form-builder-store", () => {
 		}
 
 		if (!get_docfields.value.length) {
-			let docfield = is_customize_form.value ? "Customize Form Field" : "DocField";
+			let docfield = is_web_form.value
+				? "Web Form Field"
+				: is_customize_form.value
+				? "Customize Form Field"
+				: "DocField";
 			if (!frappe.get_meta(docfield)) {
 				await load_doctype_model(docfield);
 			}
 			let df = frappe.get_meta(docfield).fields;
-			if (is_customize_form.value) {
+			if (is_web_form.value) {
+				// Deep copy to avoid mutating shared meta
+				df = JSON.parse(JSON.stringify(df));
+				web_form_docfields.value = df;
+			} else if (is_customize_form.value) {
 				custom_docfields.value = df;
 			} else {
 				docfields.value = df;
 			}
+		}
+
+		// Populate fieldname options from the parent doctype for web forms
+		if (is_web_form.value && doc.value.doc_type) {
+			await populate_web_form_fieldname_options(doc.value.doc_type);
 		}
 
 		// Preserve the currently active tab index before regenerating layout
@@ -117,6 +139,16 @@ export const useStore = defineStore("form-builder-store", () => {
 		}
 
 		form.value.layout = get_layout();
+
+		// Ensure at least one tab exists so the builder is usable on empty forms
+		// (mirrors the state a DocType has after empty-section cleanup)
+		if (form.value.layout.tabs.length === 0) {
+			form.value.layout.tabs.push({
+				df: get_df("Tab Break", "", __("Details")),
+				sections: [],
+				is_first: true,
+			});
+		}
 
 		// Try to restore the previously active tab by index if it still exists
 		if (
@@ -166,7 +198,11 @@ export const useStore = defineStore("form-builder-store", () => {
 	}
 
 	function validate_fields(fields, is_table) {
-		fields = scrub_field_names(fields);
+		// Web form fields don't need auto-generated fieldnames — they either
+		// reference a doctype field or are intentionally "virtual" (no fieldname).
+		if (!is_web_form.value) {
+			fields = scrub_field_names(fields);
+		}
 		let error_message = "";
 
 		let has_fields = fields.some((df) => {
@@ -259,7 +295,9 @@ export const useStore = defineStore("form-builder-store", () => {
 			let fields = get_updated_fields();
 			let has_error = validate_fields(fields, doc.value.istable);
 			if (has_error) return has_error;
-			frm.value.set_value("fields", fields);
+
+			let field_property = is_web_form.value ? "web_form_fields" : "fields";
+			frm.value.set_value(field_property, fields);
 			return fields;
 		} catch (e) {
 			console.error(e);
@@ -271,7 +309,9 @@ export const useStore = defineStore("form-builder-store", () => {
 	function get_updated_fields() {
 		let fields = [];
 		let idx = 0;
-		let new_field_name = is_customize_form.value
+		let new_field_name = is_web_form.value
+			? "new-web-form-field-"
+			: is_customize_form.value
 			? "new-customize-form-field-"
 			: "new-docfield-";
 
@@ -351,8 +391,36 @@ export const useStore = defineStore("form-builder-store", () => {
 		return JSON.stringify(df_copy) != JSON.stringify(new_df_copy);
 	}
 
+	async function populate_web_form_fieldname_options(parent_doctype) {
+		// Load the parent doctype meta if not already loaded
+		if (!frappe.get_meta(parent_doctype)) {
+			await load_doctype_model(parent_doctype);
+		}
+
+		let parent_fields = frappe.meta.get_docfields(parent_doctype).filter((df) => {
+			return (
+				(frappe.model.is_value_type(df.fieldtype) &&
+					!["lft", "rgt"].includes(df.fieldname)) ||
+				["Table", "Table Multiselect"].includes(df.fieldtype) ||
+				frappe.model.layout_fields.includes(df.fieldtype)
+			);
+		});
+
+		let options = parent_fields.map((df) => ({
+			label: df.label,
+			value: df.fieldname,
+		}));
+
+		// Update the fieldname field's options in our web_form_docfields
+		let fieldname_df = web_form_docfields.value.find((df) => df.fieldname === "fieldname");
+		if (fieldname_df) {
+			fieldname_df.options = options;
+		}
+	}
+
 	function get_layout() {
-		return create_layout(doc.value.fields);
+		let fields = is_web_form.value ? doc.value.web_form_fields : doc.value.fields;
+		return create_layout(fields);
 	}
 
 	// Tab actions
@@ -388,6 +456,7 @@ export const useStore = defineStore("form-builder-store", () => {
 		dirty,
 		read_only,
 		is_customize_form,
+		is_web_form,
 		preview,
 		drag,
 		get_animation,

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -90,11 +90,9 @@
 	}
 }
 
-#doctype-form_builder_tab .section-body {
-	max-width: 100% !important;
-}
-
-#customize-form-form_tab .section-body {
+#doctype-form_builder_tab .section-body,
+#customize-form-form_tab .section-body,
+#web-form-form_builder_tab .section-body {
 	max-width: 100% !important;
 }
 

--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -23,6 +23,16 @@ frappe.ui.form.on("Web Form", {
 		};
 	},
 
+	after_save: function (frm) {
+		if (
+			frappe.web_form_builder &&
+			frappe.web_form_builder.doctype === frm.doc.name &&
+			frappe.web_form_builder.store
+		) {
+			frappe.web_form_builder.store.fetch();
+		}
+	},
+
 	refresh: function (frm) {
 		// get iframe url for web form
 		frm.sidebar
@@ -46,6 +56,22 @@ frappe.ui.form.on("Web Form", {
 		frm.trigger("add_get_fields_button");
 		frm.trigger("add_publish_button");
 		frm.trigger("render_condition_table");
+
+		if (frm.doc.doc_type) {
+			render_form_builder(frm);
+		}
+	},
+
+	on_tab_change: (frm) => {
+		let current_tab = frm.get_active_tab().label;
+
+		if (current_tab === "Form") {
+			frm.footer.wrapper.hide();
+			frm.form_wrapper.addClass("mb-1");
+		} else {
+			frm.footer.wrapper.show();
+			frm.form_wrapper.removeClass("mb-1");
+		}
 	},
 
 	login_required: function (frm) {
@@ -127,7 +153,12 @@ frappe.ui.form.on("Web Form", {
 					}
 				}
 				frm.refresh_field("web_form_fields");
-				frm.scroll_to_field("web_form_fields");
+				frm.dirty();
+
+				// Re-render the form builder with the new fields
+				if (frappe.web_form_builder?.store) {
+					frappe.web_form_builder.store.fetch();
+				}
 			});
 		});
 	},
@@ -196,6 +227,9 @@ frappe.ui.form.on("Web Form", {
 
 	doc_type: function (frm) {
 		frm.trigger("set_fields");
+		if (frm.doc.doc_type) {
+			render_form_builder(frm);
+		}
 	},
 
 	allow_multiple: function (frm) {
@@ -203,6 +237,16 @@ frappe.ui.form.on("Web Form", {
 	},
 
 	before_save: function (frm) {
+		let form_builder = frappe.web_form_builder;
+		if (form_builder?.store) {
+			let fields = form_builder.store.update_fields();
+
+			// if fields is a string, it means there is an error
+			if (typeof fields === "string") {
+				frappe.throw(fields);
+			}
+		}
+
 		let static_filters = JSON.parse(frm.doc.condition_json || "[]");
 		frm.set_value("condition_json", JSON.stringify(static_filters));
 		frm.trigger("render_condition_table");
@@ -394,5 +438,35 @@ function render_list_settings_message(frm) {
 			.click(() => frm.scroll_to_field("login_required"));
 	} else {
 		$(frm.fields_dict["list_setting_message"].wrapper).empty();
+	}
+}
+
+function render_form_builder(frm) {
+	if (!frm.doc.doc_type) return;
+
+	if (frappe.web_form_builder && frappe.web_form_builder.doctype === frm.doc.name) {
+		frappe.web_form_builder.setup_page_actions();
+		frappe.web_form_builder.store.fetch();
+		return;
+	}
+
+	if (frappe.web_form_builder) {
+		frappe.web_form_builder.wrapper = $(frm.fields_dict["form_builder"].wrapper);
+		frappe.web_form_builder.frm = frm;
+		frappe.web_form_builder.doctype = frm.doc.name;
+		frappe.web_form_builder.customize = false;
+		frappe.web_form_builder.webform = true;
+		frappe.web_form_builder.init(true);
+		frappe.web_form_builder.store.fetch();
+	} else {
+		frappe.require("form_builder.bundle.js").then(() => {
+			frappe.web_form_builder = new frappe.ui.FormBuilder({
+				wrapper: $(frm.fields_dict["form_builder"].wrapper),
+				frm: frm,
+				doctype: frm.doc.name,
+				customize: false,
+				webform: true,
+			});
+		});
 	}
 }

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -5,7 +5,9 @@
  "document_type": "Document",
  "engine": "InnoDB",
  "field_order": [
-  "form_tab",
+  "form_builder_tab",
+  "form_builder",
+  "settings_tab",
   "title",
   "route",
   "published",
@@ -13,10 +15,8 @@
   "doc_type",
   "module",
   "is_standard",
-  "section_break_1",
+  "section_break_auvu",
   "introduction_text",
-  "web_form_fields",
-  "settings_tab",
   "access_control_section",
   "anonymous",
   "login_required",
@@ -47,6 +47,9 @@
   "section_break_4",
   "show_sidebar",
   "website_sidebar",
+  "form_tab",
+  "section_break_1",
+  "web_form_fields",
   "customization_tab",
   "button_label",
   "banner_image",
@@ -68,6 +71,7 @@
  ],
  "fields": [
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "title",
    "fieldtype": "Data",
    "label": "Title",
@@ -75,12 +79,14 @@
    "reqd": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "route",
    "fieldtype": "Data",
    "label": "Route",
    "unique": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "doc_type",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -90,12 +96,14 @@
    "reqd": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "module",
    "fieldtype": "Link",
    "label": "Module",
    "options": "Module Def"
   },
   {
+   "allow_in_quick_entry": 1,
    "default": "0",
    "fieldname": "is_standard",
    "fieldtype": "Check",
@@ -191,7 +199,7 @@
    "label": "Max attachment size"
   },
   {
-   "description": "For help see <a href=\"https://frappeframework.com/docs/user/en/guides/portal-development/web-forms\" target=\"_blank\">Client Script API and Examples</a>",
+   "description": "For help see <a href=\"https://frappeframework.com/docs/user/en/guides/portal-development/web-forms\" target=\"_blank\" rel=\"noopener noreferrer\">Client Script API and Examples</a>",
    "fieldname": "client_script",
    "fieldtype": "Code",
    "label": "Client script",
@@ -289,11 +297,21 @@
   {
    "fieldname": "form_tab",
    "fieldtype": "Tab Break",
-   "label": "Form"
+   "label": "Fields"
   },
   {
    "fieldname": "section_break_1",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "form_builder_tab",
+   "fieldtype": "Tab Break",
+   "label": "Form"
+  },
+  {
+   "fieldname": "form_builder",
+   "fieldtype": "HTML",
+   "label": "Form Builder"
   },
   {
    "fieldname": "settings_tab",
@@ -424,12 +442,16 @@
   {
    "fieldname": "column_break_hhec",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_auvu",
+   "fieldtype": "Section Break"
   }
  ],
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2025-12-12 16:29:35.806107",
+ "modified": "2026-02-27 07:53:59.107391",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",
@@ -445,6 +467,7 @@
    "write": 1
   }
  ],
+ "quick_entry": 1,
  "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/website/doctype/web_form/web_form_list.js
+++ b/frappe/website/doctype/web_form/web_form_list.js
@@ -8,3 +8,11 @@ frappe.listview_settings["Web Form"] = {
 		}
 	},
 };
+
+frappe.ui.form.WebFormQuickEntryForm = class WebFormQuickEntryForm extends (
+	frappe.ui.form.QuickEntryForm
+) {
+	open_form_if_not_list() {
+		frappe.set_route("Form", this.doc.doctype, this.doc.name);
+	}
+};


### PR DESCRIPTION
This integrates the core Form Builder component with the Web Form doctype in the Website module, bringing the rich form builder experience to public forms. The Web Form form layout is refactored to mirror the Doctype authoring experience, including quick entry.

Demo:
https://github.com/user-attachments/assets/ac5bcaff-5591-489b-9a32-daafee99f2ca

Closes https://github.com/frappe/frappe/issues/31509